### PR TITLE
Disable cue_consolidated_instance generation by default

### DIFF
--- a/examples/gazelle/BUILD.bazel
+++ b/examples/gazelle/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@gazelle//:def.bzl", "gazelle")
 
 # gazelle:prefix github.com/abcue/rules_cue/examples/gazelle
+# gazelle:cue_gen_consolidated_instance
 
 # Run this to update BUILD.bazel files:
 # bazel run //:gazelle

--- a/examples/gazelle/MODULE.bazel.lock
+++ b/examples/gazelle/MODULE.bazel.lock
@@ -17,6 +17,7 @@
     "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
     "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
+    "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/source.json": "b07e17f067fe4f69f90b03b36ef1e08fe0d1f3cac254c1241a1818773e3423bc",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
@@ -32,7 +33,8 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
-    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/source.json": "f121b43eeefc7c29efbd51b83d08631e2347297c95aac9764a701f2a6a2bb953",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/MODULE.bazel": "72997b29dfd95c3fa0d0c48322d05590418edef451f8db8db5509c57875fb4b7",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/source.json": "7ad77c1e8c1b84222d9b3f3cae016a76639435744c19330b0b37c0a3c9da7dc0",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
     "https://bcr.bazel.build/modules/gazelle/0.32.0/MODULE.bazel": "b499f58a5d0d3537f3cf5b76d8ada18242f64ec474d8391247438bf04f58c7b8",
@@ -53,12 +55,13 @@
     "https://bcr.bazel.build/modules/package_metadata/0.0.5/source.json": "2326db2f6592578177751c3e1f74786b79382cd6008834c9d01ec865b9126a85",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
     "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
-    "https://bcr.bazel.build/modules/platforms/0.0.11/source.json": "f7e188b79ebedebfe75e9e1d098b8845226c7992b307e28e1496f23112e8fc29",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
     "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
     "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
     "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
     "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel": "f05feb42b48f1b3c225e4ccf351f367be0371411a803198ec34a389fb22aa580",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/source.json": "f4ff1fd412e0246fd38c82328eb209130ead81d62dcd5a9e40910f867f733d96",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
     "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
@@ -87,7 +90,8 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
-    "https://bcr.bazel.build/modules/rules_cc/0.1.1/source.json": "d61627377bd7dd1da4652063e368d9366fc9a73920bfa396798ad92172cf645c",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.5/MODULE.bazel": "88dfc9361e8b5ae1008ac38f7cdfd45ad738e4fa676a3ad67d19204f045a1fd8",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.5/source.json": "4bb4fed7f5499775d495739f785a5494a1f854645fa1bac5de131264f5acdf01",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
@@ -95,8 +99,8 @@
     "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
     "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
     "https://bcr.bazel.build/modules/rules_go/0.53.0/MODULE.bazel": "a4ed760d3ac0dbc0d7b967631a9a3fd9100d28f7d9fcf214b4df87d4bfff5f9a",
-    "https://bcr.bazel.build/modules/rules_go/0.55.1/MODULE.bazel": "a57a6fc59a74326c0b440d07cca209edf13c7d1a641e48cfbeab56e79f873609",
-    "https://bcr.bazel.build/modules/rules_go/0.55.1/source.json": "827a740c8959c9d20616889e7746cde4dcc6ee80d25146943627ccea0736328f",
+    "https://bcr.bazel.build/modules/rules_go/0.59.0/MODULE.bazel": "b7e43e7414a3139a7547d1b4909b29085fbe5182b6c58cbe1ed4c6272815aeae",
+    "https://bcr.bazel.build/modules/rules_go/0.59.0/source.json": "1df17bb7865cfc029492c30163cee891d0dd8658ea0d5bfdf252c4b6db5c1ef6",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
     "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
@@ -142,8 +146,8 @@
     "https://bcr.bazel.build/modules/rules_python/0.40.0/source.json": "939d4bd2e3110f27bfb360292986bb79fd8dcefb874358ccd6cdaa7bda029320",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
     "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
-    "https://bcr.bazel.build/modules/rules_shell/0.5.0/MODULE.bazel": "8c8447370594d45539f66858b602b0bb2cb2d3401a4ebb9ad25830c59c0f366d",
-    "https://bcr.bazel.build/modules/rules_shell/0.5.0/source.json": "3038276f07cbbdd1c432d1f80a2767e34143ffbb03cfa043f017e66adbba324c",
+    "https://bcr.bazel.build/modules/rules_shell/0.6.1/MODULE.bazel": "72e76b0eea4e81611ef5452aa82b3da34caca0c8b7b5c0c9584338aa93bae26b",
+    "https://bcr.bazel.build/modules/rules_shell/0.6.1/source.json": "20ec05cd5e592055e214b2da8ccb283c7f2a421ea0dc2acbf1aa792e11c03d0c",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
     "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
@@ -161,7 +165,7 @@
   "moduleExtensions": {
     "@@rules_cue+//cue:extensions.bzl%cue": {
       "general": {
-        "bzlTransitiveDigest": "T7Ftx428/RIoWaSR7Fu+QDd+fGZXIh0Pu3uo/T05dek=",
+        "bzlTransitiveDigest": "Q5ur+mSf66GCAYogPcBgBsTH3YlDOWe6vO+Wjo6KuWs=",
         "usagesDigest": "9iY6UYjN4vIteSAoV4u4w4237UiuT04lVOsDxKym+gk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -170,14 +174,14 @@
           "cue_tool": {
             "repoRuleId": "@@rules_cue+//cue/private/tools/cue:toolchain.bzl%_download_tool",
             "attributes": {
-              "version": "v0.15.1"
+              "version": "v0.15.4"
             }
           },
           "cue_tool_toolchains": {
             "repoRuleId": "@@rules_cue+//cue/private/tools/cue:toolchain.bzl%_toolchains_repo",
             "attributes": {
               "tool_repo": "cue_tool",
-              "version": "v0.15.1"
+              "version": "v0.15.4"
             }
           }
         },

--- a/examples/gazelle/README.md
+++ b/examples/gazelle/README.md
@@ -203,6 +203,12 @@ You can customize Gazelle behavior using directives in BUILD.bazel files:
 # Control output format for CUE exports (json, yaml, text, or cue)
 # gazelle:cue_output_format yaml
 
+# Generate cue_consolidated_instance rules (opt-in)
+# gazelle:cue_gen_consolidated_instance
+
+# Disable in a subdirectory
+# gazelle:cue_gen_consolidated_instance false
+
 # Generate cue_exported_instance rules
 # gazelle:cue_gen_exported_instance
 

--- a/examples/gazelle/services/api/BUILD.bazel
+++ b/examples/gazelle/services/api/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_cue//cue:cue.bzl", "cue_consolidated_instance", "cue_instance")
+load("@rules_cue//cue:cue.bzl", "cue_instance")
 
 # gazelle:cue_gen_consolidated_instance false
 
@@ -10,12 +10,5 @@ cue_instance(
         "spec.cue",
     ],
     ancestor = "//cue.mod:cue.mod",
-    visibility = ["//visibility:public"],
-)
-
-cue_consolidated_instance(
-    name = "api_cue_def",
-    instance = ":api_cue_instance",
-    output_format = "cue",
     visibility = ["//visibility:public"],
 )

--- a/examples/gazelle/services/api/BUILD.bazel
+++ b/examples/gazelle/services/api/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@rules_cue//cue:cue.bzl", "cue_consolidated_instance", "cue_instance")
 
+# gazelle:cue_gen_consolidated_instance false
+
 cue_instance(
     name = "api_cue_instance",
     package_name = "api",

--- a/gazelle/cue/config.go
+++ b/gazelle/cue/config.go
@@ -31,12 +31,12 @@ type cueConfig struct {
 	cueTestGoldenFilename string
 
 	// cueGenExportedInstance controls whether to generate cue_exported_instance rules
-	// for each cue_instance. When true, a corresponding cue_exported_instance rule will be created.
+	// for each cue_instance. When not false, a corresponding cue_exported_instance rule will be created.
 	// #gazelle:cue_gen_exported_instance
 	cueGenExportedInstance bool
 
 	// cueGenConsolidatedInstance controls whether to generate cue_consolidated_instance rules
-	// for each cue_instance. When true, a corresponding cue_consolidated_instance rule will be created.
+	// for each cue_instance. When not false, a corresponding cue_consolidated_instance rule will be created.
 	// #gazelle:cue_gen_consolidated_instance
 	cueGenConsolidatedInstance bool
 

--- a/gazelle/cue/config.go
+++ b/gazelle/cue/config.go
@@ -32,7 +32,7 @@ type cueConfig struct {
 
 	// cueGenExportedInstance controls whether to generate cue_exported_instance rules
 	// for each cue_instance. When true, a corresponding cue_exported_instance rule will be created.
-	// #gazelle:cue_exported_instance
+	// #gazelle:cue_gen_exported_instance
 	cueGenExportedInstance bool
 
 	// cueGenConsolidatedInstance controls whether to generate cue_consolidated_instance rules
@@ -122,9 +122,9 @@ func (s *cueLang) Configure(c *config.Config, rel string, f *rule.File) {
 				conf.cueTestGoldenFilename = d.Value
 				conf.cueTestGoldenSuffix = strings.TrimPrefix(path.Ext(d.Value), ".")
 			case "cue_gen_exported_instance":
-				conf.cueGenExportedInstance = true
+				conf.cueGenExportedInstance = d.Value != "false"
 			case "cue_gen_consolidated_instance":
-				conf.cueGenConsolidatedInstance = true
+				conf.cueGenConsolidatedInstance = d.Value != "false"
 			case "cue_output_format":
 				conf.cueOutputFormat = d.Value
 			}

--- a/gazelle/cue/config.go
+++ b/gazelle/cue/config.go
@@ -35,6 +35,11 @@ type cueConfig struct {
 	// #gazelle:cue_exported_instance
 	cueGenExportedInstance bool
 
+	// cueGenConsolidatedInstance controls whether to generate cue_consolidated_instance rules
+	// for each cue_instance. When true, a corresponding cue_consolidated_instance rule will be created.
+	// #gazelle:cue_gen_consolidated_instance
+	cueGenConsolidatedInstance bool
+
 	// cueOutputFormat specifies the output format for CUE exports.
 	// Valid values are "json", "yaml", and "text".
 	// Default is "json" if not specified.
@@ -45,7 +50,7 @@ type cueConfig struct {
 // Configurer can interpret. Gazelle prints errors for directives that
 // are not recognized by any Configurer.
 func (s *cueLang) KnownDirectives() []string {
-	return []string{"prefix", "cue_test_golden_suffix", "cue_test_golden_filename", "cue_output_format", "cue_gen_exported_instance"}
+	return []string{"prefix", "cue_test_golden_suffix", "cue_test_golden_filename", "cue_output_format", "cue_gen_exported_instance", "cue_gen_consolidated_instance"}
 }
 
 // RegisterFlags registers command-line flags used by the
@@ -118,6 +123,8 @@ func (s *cueLang) Configure(c *config.Config, rel string, f *rule.File) {
 				conf.cueTestGoldenSuffix = strings.TrimPrefix(path.Ext(d.Value), ".")
 			case "cue_gen_exported_instance":
 				conf.cueGenExportedInstance = true
+			case "cue_gen_consolidated_instance":
+				conf.cueGenConsolidatedInstance = true
 			case "cue_output_format":
 				conf.cueOutputFormat = d.Value
 			}

--- a/gazelle/cue/generate.go
+++ b/gazelle/cue/generate.go
@@ -61,7 +61,7 @@ func (cl *cueLang) GenerateRules(args language.GenerateArgs) language.GenerateRe
 		consolidatedInstances:    make(map[string]*cueConsolidatedInstance),
 		exportedGoldenFiles:      make(map[string]*GoldenFile), // key: filename
 		cueTestRules:             make(map[string]*cueTest),
-		genConsolidatedInstances: true,
+		genConsolidatedInstances: conf.cueGenConsolidatedInstance,
 		genExportedInstances:     conf.cueGenExportedInstance,
 	}
 


### PR DESCRIPTION
## Summary

- Add `cue_gen_consolidated_instance` gazelle directive to opt-in to generating `cue_consolidated_instance` rules. Previously these were always generated, now they require explicit opt-in.
- Support `false` value to disable the directive in subdirectories (e.g., `# gazelle:cue_gen_consolidated_instance false`), allowing per-package control.
- Fix comment for `cue_gen_exported_instance` directive to match its actual name.
- Apply the same enable/disable support to `cue_gen_exported_instance`.
- Update `examples/gazelle/` to demonstrate both opt-in at root and opt-out in `services/api/`.

## Usage

```python
# Enable in root BUILD.bazel
# gazelle:cue_gen_consolidated_instance

# Disable in a subdirectory
# gazelle:cue_gen_consolidated_instance false
```

## Test plan

- [x] Verified `config/` and `contacts/` retain `cue_consolidated_instance` rules with directive enabled
- [x] Verified `services/api/` does not regenerate `cue_consolidated_instance` with directive set to `false`
- [x] Ran `bazel run //:gazelle` in `examples/gazelle/` to confirm correct behavior